### PR TITLE
Fix controlling_process fun in dispcount handler

### DIFF
--- a/src/dlhttpc_handler.erl
+++ b/src/dlhttpc_handler.erl
@@ -45,7 +45,7 @@ checkout(_From, State = #state{given=true}) ->
     {error, busy, State};
 checkout(From, State = #state{resource={ok, Socket}, ssl=Ssl}) ->
     dlhttpc_sock:setopts(Socket, [{active,false}], Ssl),
-    case gen_tcp:controlling_process(Socket, From) of
+    case dlhttpc_sock:controlling_process(Socket, From, Ssl) of
         ok ->
             {ok, {self(), Socket}, State#state{given=true}};
         {error, badarg} -> % caller died


### PR DESCRIPTION
@ferd hey, I found this bug in dlhttpc. It was causing an exception:

``` erlang
10> dlhttpc:request("https://www.google.com", get, [], [], 10000, []).
=ERROR REPORT==== 17-Nov-2014::14:51:23 ===
** Generic server <0.110.0> terminating
** Last message in was {get,<0.144.0>}
** When Server state == {state,dlhttpc_handler,
                            {state,
                                {error,undefined},
                                false,
                                {"www.google.com",443,true,infinity,
                                 [binary,{packet,http},{active,false}]},
                                undefined},
                            {config,'dispcount_www.google.com443_ssl',10,ets,
                                57386,61483},
                            10,undefined}
** Reason for termination ==
** {error,function_clause}
```
