### PR TITLE
Prevent closing undefined socket

### DIFF
--- a/src/dlhttpc_client.erl
+++ b/src/dlhttpc_client.erl
@@ -146,10 +146,10 @@ execute(ReqId, From, Host, Port, Ssl, Path, Method, Hdrs, Body, Options) ->
             PartialDownloadOptions, infinity)
     },
     Response = case {MaxConnections, send_request(State)} of
+        {_, {R, undefined}} ->
+            {ok, R};
         {bypass, {R, NewSocket}} ->
             dlhttpc_sock:close(NewSocket, Ssl),
-            {ok, R};
-        {_, {R, undefined}} ->
             {ok, R};
         {_, {R, NewSocket}} ->
             % The socket we ended up doing the request over is returned


### PR DESCRIPTION
@ferd hey, another thing that cause an exception.

I am using `{max_connections, bypass}` option.

After request server closes connection and sends headers:

``` erlang
{ok,{{400,"Bad Request"},
     [{"Content-Type","application/json"},
      {"Content-Length","111"},
      {"Date","Mon, 17 Nov 2014 16:37:58 GMT"},
      {"Server","Cowboy"},
      {"Connection","close"}],
     <<"body message">>}}
```

In this situation socket is closed in function: `dlhttpc_client:maybe_close_socket/5`.
So basically reordering patterns in case expression will solve an issue of trying to close socket twice.

TL;DR
Exception I was getting:

``` erlang
** exception exit: {function_clause,[{tls,close,
                                          [undefined],
                                          [{file,"tls.erl"},{line,262}]},
                                     {dlhttpc_sock,close,2,
                                                   [{file,"src/dlhttpc_sock.erl"},{line,178}]},
                                     {dlhttpc_client,execute,10,
                                                     [{file,"src/dlhttpc_client.erl"},{line,150}]},
                                     {dlhttpc_client,request,10,
                                                     [{file,"src/dlhttpc_client.erl"},{line,84}]}]}
     in function  dlhttpc:request/9 (src/dlhttpc.erl, line 363)
```
