### PR TITLE
Fix connection_timeout kinda-typo

### DIFF
--- a/include/dlhttpc_types.hrl
+++ b/include/dlhttpc_types.hrl
@@ -32,7 +32,6 @@
 -type option() ::
         {connect_options, [term()]} |
         {connect_timeout, timeout()} |
-        {connection_timeout, timeout()} |
         {max_connections, pos_integer() | bypass} |
         {stream_to, pid()} |
         {send_retry, non_neg_integer()} |

--- a/src/dlhttpc.erl
+++ b/src/dlhttpc.erl
@@ -586,11 +586,6 @@ verify_options([{connect_timeout, infinity} | Options], Errors) ->
 verify_options([{connect_timeout, MS} | Options], Errors)
         when is_integer(MS), MS >= 0 ->
     verify_options(Options, Errors);
-verify_options([{connection_timeout, infinity} | Options], Errors) ->
-    verify_options(Options, Errors);
-verify_options([{connection_timeout, MS} | Options], Errors)
-        when is_integer(MS), MS >= 0 ->
-    verify_options(Options, Errors);
 verify_options([{max_connections, N} | Options], Errors)
         when is_integer(N), N > 0; N =:= bypass ->
     verify_options(Options, Errors);

--- a/src/dlhttpc_client.erl
+++ b/src/dlhttpc_client.erl
@@ -106,7 +106,7 @@ execute(ReqId, From, Host, Port, Ssl, Path, Method, Hdrs, Body, Options) ->
     PartialDownloadOptions = proplists:get_value(partial_download, Options, []),
     NormalizedMethod = dlhttpc_lib:normalize_method(Method),
     MaxConnections = proplists:get_value(max_connections, Options, 10),
-    ConnectionTimeout = proplists:get_value(connection_timeout, Options, infinity),
+    ConnectionTimeout = proplists:get_value(connect_timeout, Options, infinity),
     {ChunkedUpload, Request} = dlhttpc_lib:format_request(Path, NormalizedMethod,
         Hdrs, Host, Port, Body, PartialUpload),
     ConnectOptions = proplists:get_value(connect_options, Options, []),


### PR DESCRIPTION
@ferd Hey, yet another fix.
In `Options` there is no such thing as `connect_timeout`.

It is being extracted earlier: `ConnectionTimeout = proplists:get_value(connection_timeout, Options, infinity)`

Without that we have `connection_timeout` always being set to `infinity`.
